### PR TITLE
waffle.io Badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+[![Stories in Ready](https://badge.waffle.io/SiliconDetector/DetectorModels.png?label=ready&title=Ready)](https://waffle.io/SiliconDetector/DetectorModels)
 # DetectorModels
 This repository contains different detector models for the SiD concept
 


### PR DESCRIPTION
Merge this to receive a badge indicating the number of issues in the ready column on your waffle.io board at https://waffle.io/SiliconDetector/DetectorModels

This was requested by a real person (user jstrube) on waffle.io, we're not trying to spam you.
