### PR TITLE
Changed absorber, air gap, added tolerance gap

### DIFF
--- a/SiD_o2_v01_prelim/HCalBarrel_o2_v01_00.xml
+++ b/SiD_o2_v01_prelim/HCalBarrel_o2_v01_00.xml
@@ -27,30 +27,22 @@
   </envelope>
 
   <staves />
-  <layer repeat="39">
-        <slice material = "Steel235"   thickness = "11.617*mm" />  <!-- Absorber -->
+  <layer repeat="40">
+    <slice material = "Steel235"   thickness = "19.0*mm" />    <!-- Absorber -->
 	<slice material = "Air"        thickness =  "2.0*mm" />
 	<slice material = "Steel235"   thickness =  "0.5*mm" />    <!-- Top plate -->
 	<slice material = "Kapton"    thickness = "0.115*mm" />    <!-- Polyimide foil -->
 	<slice material = "Copper"    thickness = "0.068*mm" />
 	<slice material = "PCB"       thickness =   "1.0*mm" />    <!-- PCB made of FR4 -->
-	<slice material = "Polystyrole" thickness = "0.1*mm" />    <!-- Reflector foil -->
+	<slice material = "Polystyrole" thickness = "0.1*mm" /> <!-- Reflector foil -->
 	<slice material = "Polystyrene" thickness = "3.0*mm" sensitive="yes" limits="cal_limits" />
-	<slice material = "Polystyrole" thickness = "0.1*mm" />    <!-- Reflector foil -->
-	<slice material = "Steel235"    thickness = "0.5*mm" />    <!-- Bottom plate -->
-	<slice material = "Air"         thickness = "8.0*mm" />
+	<slice material = "Polystyrole" thickness = "0.1*mm" /> <!-- Reflector foil -->
+	<slice material = "Steel235"    thickness = "0.5*mm" /> <!-- Bottom plate -->
+	<slice material = "Air"       thickness = "0.617*mm" >  <!-- Clearance gap between active layer and next absorber -->
   </layer>
-  <layer repeat="1">
-        <slice material = "Steel235"   thickness = "11.617*mm" />  <!-- Absorber -->
-        <slice material = "Air"        thickness =  "2.0*mm" />
-        <slice material = "Steel235"   thickness =  "0.5*mm" />    <!-- Top plate -->
-        <slice material = "Kapton"    thickness = "0.115*mm" />    <!-- Polyimide foil -->
-        <slice material = "Copper"    thickness = "0.068*mm" />
-        <slice material = "PCB"       thickness =   "1.0*mm" />    <!-- PCB made of FR4 -->
-        <slice material = "Polystyrole" thickness = "0.1*mm" />    <!-- Reflector foil -->
-        <slice material = "Polystyrene" thickness = "3.0*mm" sensitive="yes" limits="cal_limits" />
-        <slice material = "Polystyrole" thickness = "0.1*mm" />    <!-- Reflector foil -->
- 	<slice material = "Steel235"   thickness = "19.0*mm" />    <!-- Terminator plate -->
+  <!--layer repeat="1"-->
+	<!--slice material = "Steel235"   thickness = "19.0*mm" /--><!-- Terminator plate -->
+  <!--/layer-->
  </detector>
 </detectors>
 


### PR DESCRIPTION
As per SiDparJuly2016HCAL.pdf, the steel absorber plates should have a thickness of 19mm, and the entire active layer, including tolerance, should have a thickness of 8mm.

Changed Steel absorber plate thickness to 19mm
Added 0.617mm air gap for tolerance by subtracting current active layer thickness from clearance gap as specified in the model (8mm-7.383mm=0.617mm)
Removed end plate for now - will need discussion regarding potential usefulness of leaving off end plate to other physics studies (muons, etc)